### PR TITLE
Update database_mysql.rb

### DIFF
--- a/cookbooks/zabbix/recipes/database_mysql.rb
+++ b/cookbooks/zabbix/recipes/database_mysql.rb
@@ -126,7 +126,7 @@ ruby_block "zabbix_ensure_super_admin_user_with_api_access" do
     username   = node.zabbix.api.username
     first_name = 'Zabbix'
     last_name  = 'Administrator'
-    md5        = Digest::MD5.hexdigest(node.zabbix.api.password)
+    md5        = Digest::SHA2.new(512).hexdigest(node.zabbix.api.password)
     rows       = 200
     type       = 3
     grp_name   = node.zabbix.api.user_group


### PR DESCRIPTION
Greetings,

I am a security researcher, who is looking for coding patterns that are indicative of security weaknesses in Chef scripts. In your repo I found instances of MD5 usage within Chef scripts. MD5 is breakable (http://merlot.usc.edu/csac-f06/papers/Wang05a.pdf). According to the Common Weakness Enumeration organization this is a security weakness
(CWE-327: Use of a Broken or Risky Cryptographic Algorithm https://cwe.mitre.org/data/definitions/327.html).

MD5 has security weaknesses, better to use SHA 512. Any feedback is welcome. Addresses issue: https://github.com/cookbooks/ic-graphite/issues/1